### PR TITLE
Fix out of range issue 

### DIFF
--- a/Unity Project/Assets/Plugins/Farrokh Games/Language/Editor/Tests/LanguageManagerTests.cs
+++ b/Unity Project/Assets/Plugins/Farrokh Games/Language/Editor/Tests/LanguageManagerTests.cs
@@ -159,5 +159,15 @@ namespace FarrokhGames.Language
             manager.CurrentLanguage = SystemLanguage.Swedish;
             Assert.That(manager.Get("test4", "test"), Is.EqualTo("English only text with parameter test"));
         }
+
+
+        [Test]
+        public void FallbackOnly_OrCurrentLanguageMissing_WorksAsIntended()
+        {
+            var manager = new LanguageManager(GetEnglish());
+            Assert.That(manager.Contains("test1"), Is.True);
+            Assert.That(manager.Get("test1"), Is.EqualTo("Short text"));
+            Assert.That(manager.Get("test2", "good looking"), Is.EqualTo("Text with one good looking parameter."));
+        }
     }
 }

--- a/Unity Project/Assets/Plugins/Farrokh Games/Language/LanguageManager.cs
+++ b/Unity Project/Assets/Plugins/Farrokh Games/Language/LanguageManager.cs
@@ -79,7 +79,7 @@ namespace FarrokhGames.Language
         /// <param name="id">Identifier</param>
         public bool Contains(string id)
         {
-            if (_containers[_currentLanguage].Contains(id))
+            if (_containers[CurrentLanguage].Contains(id))
             {
                 return true;
             }
@@ -93,9 +93,9 @@ namespace FarrokhGames.Language
         /// <returns>Localized string</returns>
         public string Get(string id)
         {
-            if (_containers[_currentLanguage].Contains(id))
+            if (_containers[CurrentLanguage].Contains(id))
             {
-                return _containers[_currentLanguage].Get(id);
+                return _containers[CurrentLanguage].Get(id);
             }
             return _fallbackLanguage.Get(id);
         }
@@ -108,9 +108,9 @@ namespace FarrokhGames.Language
         /// <returns>Localized string</returns>
         public string Get(string id, params object[] parameters)
         {
-            if (_containers[_currentLanguage].Contains(id))
+            if (_containers[CurrentLanguage].Contains(id))
             {
-                return _containers[_currentLanguage].Get(id, parameters);
+                return _containers[CurrentLanguage].Get(id, parameters);
             }
             return _fallbackLanguage.Get(id, parameters);
         }


### PR DESCRIPTION
When current language was missing, or when fallback was the only available language LanguageManager operations could result in out of range exceptions.